### PR TITLE
Fixed behavior for branching graphs

### DIFF
--- a/src/DeepShiba.jl
+++ b/src/DeepShiba.jl
@@ -1,5 +1,5 @@
 module DeepShiba
     include("core_simple.jl")
     include("utils.jl")
-    export  Variable, Func, variable, func, backward!, numerical_diff, cleargrad
+    export  Variable, Func, variable, func, backward!, numerical_diff, cleargrad, print
 end 

--- a/src/core_simple.jl
+++ b/src/core_simple.jl
@@ -1,4 +1,8 @@
+import Base
 using DataStructures
+
+
+
 
 mutable struct Variable
     data
@@ -18,9 +22,9 @@ mutable struct Func
 end
 
 
-variable(data, name=nothing) = Variable(data, nothing, nothing, 0, name)
+variable(data, name = nothing) = Variable(data, nothing, nothing, 0, name)
 
-func(forward, backward, name=nothing) = Func(forward, backward, nothing, nothing, 0, name)
+func(forward, backward, name = nothing) = Func(forward, backward, nothing, nothing, 0, name)
 
 
 function ones_like(x)
@@ -36,6 +40,8 @@ end
 
 get_data(var::Variable) = var.data
 
+get_generation(var::Variable) = var.generation
+
 function cleargrad(var::Variable)
     var.grad = nothing
 end
@@ -45,23 +51,27 @@ function (f::Func)(vars::Variable...)
     xs = [x.data for x in vars]
     ys = f.forward(xs...)
     ys = as_tuple(ys)
-    outputs = [Variable(y, f, nothing, f.generation + 1, nothing) for y in ys]
     f.generation = maximum([x.generation for x in f.inputs])
+    outputs = [Variable(y, f, nothing, f.generation - 1, nothing) for y in ys]  
+    # Why is the generation decimating?
+        #= At the time of backpropagation, we use a priority queue to take out the smallest number of generations in order.
+        So, the closer you are to the output layer, the smaller the generation needs to be.. =#
     f.outputs = outputs
     length(outputs)  == 1 ? outputs[1] : outputs
 end
 
 
-function backward!(var::Variable)
+function backward!(var::Variable, debug = false)
     (isnothing(var.grad)) && (var.grad = ones_like(var.data))
-    funcs = PriorityQueue{Func, Int}()
+    funcs = PriorityQueue{Func,Int}()
     seen_set = Set{Func}()
     funcs[var.creator] = 1
+    push!(seen_set, var.creator)
     while !(isempty(funcs))
         f = dequeue!(funcs)
         gys = [output.grad for output in f.outputs]
         inputs = get_data.(f.inputs)
-        gxs =  f.backward.(inputs) .* gys
+        gxs =  f.backward(inputs...) .* gys
         gxs = tuple(gxs...)
         for (x, gx) in zip(f.inputs, gxs)
             if isnothing(x.grad) 
@@ -69,11 +79,36 @@ function backward!(var::Variable)
             else
                 x.grad = x.grad + gx
             end
-            if (!(isnothing(x.creator))) 
-                if !(x.creator in seen_set)
-                    funcs[x.creator] = x.generation
-                end
+            if (!(isnothing(x.creator))) && (!(x.creator in seen_set))
+                push!(seen_set, x.creator)
+                enqueue!(funcs, x.creator, x.creator.generation)
             end
         end
     end
 end
+
+
+Add(x1, x2) = func(
+    (x1, x2)->x1 + x2,
+    (x1, x2)->1, 1
+)(x1, x2)
+
+Sub(x1, x2) = func(
+    (x1, x2)->x1 - x2,
+    x->(1, -1)
+)(x1, x2)
+
+Neg(x) = func(
+    x->-x,
+    x->-x
+)
+
+Mul(x1, x2) = func(
+    (x1, x2)->x1 * x2,
+    x->(x, x)
+)
+
+Div(x1, x2) = func(
+    (x1, x2)->x1 / x2,
+    nothing
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,10 +13,11 @@ const e = 10e-5
 end
 
 @testset "DiffTest" begin
+    # ===================
     x = variable(0.5)
     f(x) = Func(
-        x -> x^2,
-        x -> 2x,
+        x->x^2,
+        x->2x,
         nothing,
         nothing,
         0,
@@ -26,19 +27,23 @@ end
     y.grad = 1
     backward!(y)
     @test 1.0 - e <= x.grad <= 1.0 + e
+    # ===================
+    
+    
+    # ===================
     Square(x) = func(
-        x -> x^2,
-        x -> 2x
+        x->x^2,
+        x->2x
     )(x)
 
     Exp(x) = func(
-        x -> exp(x),
-        x -> exp(x),
+        x->exp(x),
+        x->exp(x),
     )(x)
 
     Add(x1, x2) = func(
-        (x1, x2) -> x1 + x2,
-        x -> 1,
+        (x1, x2)->x1 + x2,
+        (x1, x2)->(1, 1)
     )(x1, x2)
 
 
@@ -47,5 +52,28 @@ end
     y = Add(Square(x1), Exp(x2))
     backward!(y)
     @test ((0.5^2) + exp(1.5) - e) <= y.data <= ((0.5^2) + exp(1.5) + e)
-end
+    # ===================
 
+    # ===================
+    x = variable(2.0)
+
+    Square(x) = func(
+        x->x^2,
+        x->2x,
+        "Square"
+    )(x)
+
+
+    Add(x1, x2) = func(
+    (x1, x2)->x1 + x2,
+    (x1, x2)->(1, 1),
+    "Add"
+    )(x1, x2)
+
+    a = Square(x)
+    y = Add(Square(a), Square(a))
+    backward!(y)
+    @test 32.0 - e <= y.data <= 32.0 + e
+    @test 64.0 - e <= x.grad <= 64.0 + e 
+    # =====================
+end


### PR DESCRIPTION
DeepShiba used PriorityQueue to manage the order in which functions are fetched. (See #12).

However, because the number of generations was not set properly,back propagation did not work properly in some cases.
That is resolved with this pull request.