### PR TITLE
Overload an operator

### DIFF
--- a/src/DeepShiba.jl
+++ b/src/DeepShiba.jl
@@ -1,5 +1,5 @@
 module DeepShiba
     include("core_simple.jl")
     include("utils.jl")
-    export  Variable, Func, variable, func, backward!, numerical_diff, cleargrad, print
+    export  Variable, Func, variable, func, backward!, numerical_diff, cleargrad, print, +, -, *, /
 end 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,7 +7,7 @@ function Base.print(x::Variable, debug=true)
         println()
         (x.grad !== nothing) && println("grad:",x.grad)
         if (x.creator !== nothing)
-            (x.creator.name !== nothing) && (println("creator:",x.creator.name))
+            (x.creator.name !== nothing) && (println("creator:", x.creator.name))
         end
     end
     println(")")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,21 @@
 using Test
 using DeepShiba
+using Random
 
 
-const e = 10e-5
+function isAbout(x, y, e=10e-5)
+    return x - e <= x <= x + e
+end
 
 @testset "NumericalDiffTest" begin
     f(x) = 2x^3 + x^2 + 3x + 2
     f′(x) = 6x^2 + 2x + 3
     for i in 0:0.1:1
-        @test (f′(i) - e) <= (numerical_diff(f, i)) <= (f′(i) + e) 
+        num_diff = numerical_diff(f, i)
+        @test isAbout(num_diff, f′(i)) 
     end
 end
+
 
 @testset "DiffTest" begin
     # ===================
@@ -26,24 +31,24 @@ end
     y = f(x)
     y.grad = 1
     backward!(y)
-    @test 1.0 - e <= x.grad <= 1.0 + e
+    @test isAbout(x.grad, 1.0)
     # ===================
     
     
     # ===================
     Square(x) = func(
-        x->x^2,
-        x->2x
+        x -> x^2,
+        x -> 2x
     )(x)
 
     Exp(x) = func(
-        x->exp(x),
-        x->exp(x),
+        x -> exp(x),
+        x -> exp(x),
     )(x)
 
     Add(x1, x2) = func(
-        (x1, x2)->x1 + x2,
-        (x1, x2)->(1, 1)
+        (x1, x2) -> x1 + x2,
+        (x1, x2) -> (1, 1)
     )(x1, x2)
 
 
@@ -51,29 +56,42 @@ end
     x2 = variable(1.5)
     y = Add(Square(x1), Exp(x2))
     backward!(y)
-    @test ((0.5^2) + exp(1.5) - e) <= y.data <= ((0.5^2) + exp(1.5) + e)
+    @test isAbout(y.data, (0.5^2) + exp(1.5))
     # ===================
 
     # ===================
     x = variable(2.0)
 
     Square(x) = func(
-        x->x^2,
-        x->2x,
+        x -> x^2,
+        x -> 2x,
         "Square"
     )(x)
 
 
     Add(x1, x2) = func(
-    (x1, x2)->x1 + x2,
-    (x1, x2)->(1, 1),
+    (x1, x2) -> x1 + x2,
+    (x1, x2) -> (1, 1),
     "Add"
     )(x1, x2)
 
     a = Square(x)
     y = Add(Square(a), Square(a))
     backward!(y)
-    @test 32.0 - e <= y.data <= 32.0 + e
-    @test 64.0 - e <= x.grad <= 64.0 + e 
+    @test isAbout(y.data, 32)
+    @test isAbout(x.grad, 54)
     # =====================
+
+    # =====================
+    sphere(x, y) = x^2 + y^2
+
+    x = variable(1.0)
+    y = variable(1.0)
+    z = sphere(x, y)
+    backward!(z)
+    @test isAbout(x.grad, 2)
+    @test isAbout(y.grad, 2)
+
+    # ====================
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using DeepShiba
-using Random
+
 
 
 function isAbout(x, y, e=10e-5)


### PR DESCRIPTION
(fix #17)

DeepShiba can now write operations more intuitively by overloading Julia's operators.

Example:
```julia
sphere(x, y) = x^2 + y^2
x = variable(1.0)
y = variable(1.0)
z = sphere(x, y)
backward!(z)

print(x) 
#=
->
Variable(
data:1.0
grad:2.0
)=#

print(y)
#=
Variable(
data:1.0
grad:2.0
)
=#
```