### PR TITLE
Update plot features

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+ElectronDisplay = "d872a56f-244b-5cc9-b574-2017b5b909a8"
 
 [compat]
 julia = "1.4"

--- a/src/utils/plot.jl
+++ b/src/utils/plot.jl
@@ -93,12 +93,16 @@ function plot(var::Variable; to_file = "", show_value=0, title="")
                 PNGContainer(read(io))
             end
             display(c)
-        else
+        elseif PROGRAM_FILE == ""
             png_file_path = plot_tmp_dir(".png")
             c = open(png_file_path) do io
                 PNGContainer(read(io))
             end
             display(c)
+        else
+            error("Plotting from the script is not supported. 
+If you want to plot, use REPL or Jupyter, or use the argument to_file.
+            ")
         end
     else
         extension = split(to_file, ".")[2]

--- a/src/utils/plot.jl
+++ b/src/utils/plot.jl
@@ -1,3 +1,4 @@
+using ElectronDisplay
 const tmp_dir = join([expanduser("~"),".DeepShiba"], "/")
 const dot_file_path = join([tmp_dir,"tmp_graph.dot"], "/")
 
@@ -88,8 +89,11 @@ function plot(var::Variable; to_file = "")
             end
             display(c)
         else
-            plot_tmp_dir(".png")
-
+            png_file_path = plot_tmp_dir(".png")
+            c = open(png_file_path) do io
+                PNGContainer(read(io))
+            end
+            display(c)
         end
     else
         extension = split(to_file, ".")[2]

--- a/src/utils/plot.jl
+++ b/src/utils/plot.jl
@@ -10,18 +10,19 @@ function Base.show(io::IO, ::MIME"image/png", c::PNGContainer)
     write(io, c.content)
 end
 
-function _dot_var(var::Variable)
+function _dot_var(var::Variable, show_value)
     name = var.name == "" ? "" : var.name * ":"
+    value = (show_value == 0 ? var.data : var.grad.data)
     if var.data !== nothing
-        var_size = size(var.data)
+        var_size = size(value)
         if isempty(var_size)
             try var.data !== nothing
-                name *= "$(var.data)"
+                name *= "$(value)"
             catch
                 name *= "nothing"
             end
         else    
-            name *= "shape: $(var_size) \n type: $(get_value_type(var.data))"
+            name *= "shape: $(var_size) \n type: $(get_value_type(value))"
         end
     end
     dot_var = "$(objectid(var)) [label=\"$name\", color=orange, style=filled]\n"
@@ -43,17 +44,17 @@ function _dot_func(f::Func)
     return txt
 end
 
-function get_dot_graph(var)
+function get_dot_graph(var, show_value, title)
     txt = ""
     funcs = []
     seen_set = Set{Func}()
     push!(funcs, var.creator)
-    txt = _dot_var(var)
+    txt = _dot_var(var, show_value)
     while !(isempty(funcs))
         f = pop!(funcs)
         txt *= _dot_func(f)
         for x in f.inputs
-            txt *= _dot_var(x)
+            txt *= _dot_var(x, show_value)
             if x.creator !== nothing && (!(x.creator in seen_set))
                 push!(seen_set, x.creator)
                 push!(funcs, x.creator)
@@ -61,6 +62,10 @@ function get_dot_graph(var)
         end
     end
     return "digraph g {
+            graph [
+                labelloc=\"t\";
+                label= \"$(title)\"
+            ];
                 $txt 
             }"
 end
@@ -74,8 +79,8 @@ function plot_tmp_dir(extension)
     return to_file
 end
 
-function plot(var::Variable; to_file = "")
-    dot_graph = get_dot_graph(var)
+function plot(var::Variable; to_file = "", show_value=0, title="")
+    dot_graph = get_dot_graph(var, show_value, title)
     (!(ispath(tmp_dir))) && (mkdir(tmp_dir))
     open(dot_file_path, "w") do io
         write(io, dot_graph)


### PR DESCRIPTION
# Changes
## fix #43 
The title and output value can now be changed when plotting.

## fix #50 

You can now plot directly in Jupyter or REPL without saving to a file.

## fix #53 

We decided not to respond to plots directly from the script because we thought there would be less demand for it.
If you try to plot directly from the script, you will get an error.